### PR TITLE
feat: add functionality to create static mind maps from Studio

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,16 @@ Unreleased
 
 *
 
+0.3.0 - 2023-08-04
+**********************************************
+
+Added
+=====
+
+* Add test suite for Mind Map class definition
+* Add functionality to create static mind maps from Studio
+
+
 0.2.0 - 2023-07-28
 **********************************************
 

--- a/mindmap/__init__.py
+++ b/mindmap/__init__.py
@@ -4,4 +4,4 @@ Init for the MindMapXBlock package.
 
 from .mindmap import MindMapXBlock
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'

--- a/mindmap/mindmap.py
+++ b/mindmap/mindmap.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-from http import HTTPStatus
 from typing import Tuple
 
 import boto3
@@ -15,7 +14,7 @@ from django.template import Context, Template
 from django.utils import translation
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock
-from xblock.fields import Scope, String
+from xblock.fields import Boolean, Scope, String
 from xblockutils.resources import ResourceLoader
 
 log = logging.getLogger(__name__)
@@ -42,6 +41,13 @@ class MindMapXBlock(XBlock):
     display_name = String(
         display_name="Display Name",
         default="Mind Map",
+        scope=Scope.settings,
+    )
+
+    is_static = Boolean(
+        help="Whether the mind map is static or not",
+        display_name="Is Static",
+        default=False,
         scope=Scope.settings,
     )
 
@@ -89,6 +95,31 @@ class MindMapXBlock(XBlock):
         template = Template(template_str)
         return template.render(Context(context))
 
+    def get_student_view_attrs(self, user):
+        """
+        Return the attributes for the student view.
+
+        Args:
+            user: The current user
+
+        Returns:
+            dict: The attributes for the student view
+        """
+        anonymous_user_id = self.anonymous_user_id(user)
+        in_student_view = self.is_student(user) or self.user_is_staff(user)
+        suffix = (
+            anonymous_user_id
+            if in_student_view and not self.is_static
+            else "instructor"
+        )
+        editable = in_student_view != self.is_static
+
+        return {
+            "in_student_view": in_student_view,
+            "suffix": suffix,
+            "editable": editable,
+        }
+
     def student_view(self, _context=None) -> Fragment:
         """
         The primary view of the MindMapXBlock, shown to students when viewing courses.
@@ -100,20 +131,25 @@ class MindMapXBlock(XBlock):
             Fragment: The fragment to render
         """
         user = self.get_current_user()
-        anonymous_user_id = self.anonymous_user_id(user)
-        show_mindmap = self.is_student(user) or self.user_is_staff(user)
+        view_attrs = self.get_student_view_attrs(user)
         js_context = {"author": user.full_name}
         error_message = None
 
-        if show_mindmap:
+        if view_attrs["in_student_view"] or self.is_static:
             try:
-                mind_map = self.get_current_mind_map(anonymous_user_id)
-                js_context.update({"mind_map": mind_map})
+                mind_map = self.get_current_mind_map(view_attrs["suffix"])
+                js_context.update(
+                    {"mind_map": mind_map, "editable": view_attrs["editable"]}
+                )
             except Exception as error: # pylint: disable=broad-except
                 log.exception("Error while setting up student view of MindMapXBlock")
                 error_message = str(error)
 
-        context = {"show_mindmap": show_mindmap, "error_message": error_message}
+        context = {
+            "in_student_view": view_attrs["in_student_view"],
+            "is_static": self.is_static,
+            "error_message": error_message,
+        }
 
         html = self.render_template("static/html/mindmap.html", context)
         frag = Fragment(html.format(self=self))
@@ -122,8 +158,11 @@ class MindMapXBlock(XBlock):
         # Add i18n js
         statici18n_js_url = self._get_statici18n_js_url()
         if statici18n_js_url:
-            frag.add_javascript_url(self.runtime.local_resource_url(self, statici18n_js_url))
+            frag.add_javascript_url(
+                self.runtime.local_resource_url(self, statici18n_js_url)
+            )
 
+        frag.add_javascript(self.resource_string("static/js/src/requiredModules.js"))
         frag.add_javascript(self.resource_string("static/js/src/mindmap.js"))
         frag.initialize_js('MindMapXBlock', json_args=js_context)
         return frag
@@ -139,7 +178,11 @@ class MindMapXBlock(XBlock):
             Fragment: The fragment to render
         """
         context = {
+            # Field values
             "display_name": self.display_name,
+            "is_static": self.is_static,
+            # Field attributes
+            "is_static_field": self.fields["is_static"],
         }
 
         html = self.render_template("static/html/mindmap_edit.html", context)
@@ -149,7 +192,9 @@ class MindMapXBlock(XBlock):
         # Add i18n js
         statici18n_js_url = self._get_statici18n_js_url()
         if statici18n_js_url:
-            frag.add_javascript_url(self.runtime.local_resource_url(self, statici18n_js_url))
+            frag.add_javascript_url(
+                self.runtime.local_resource_url(self, statici18n_js_url)
+            )
 
         frag.add_javascript(self.resource_string("static/js/src/mindmapEdit.js"))
         frag.initialize_js("MindMapXBlock")
@@ -181,65 +226,52 @@ class MindMapXBlock(XBlock):
 
         return s3_client, aws_bucket_name
 
-    def get_file_key(self, anonymous_user_id: str) -> str:
+    def get_file_key(self, suffix: str) -> str:
         """
         Return the key (path) to save and retrieve the file in S3.
+
+        Args:
+            suffix (str): The suffix to use in the key (path).
 
         Returns:
             str: The key (path) to use in S3.
         """
         block_id = self.scope_ids.usage_id.block_id
-        return f"mindmaps/{block_id}/{anonymous_user_id}/mindmap.json"
+        return f"mindmaps/{block_id}/{suffix}/mindmap.json"
 
-    def file_exists_in_s3(self, anonymous_user_id: str) -> bool:
-        """
-        Check if the file exists in S3.
-
-        Returns:
-            bool: True if the file exists, False otherwise.
-        """
-        s3_client, aws_bucket_name = self.connect_to_s3()
-        try:
-            s3_client.head_object(
-                Bucket=aws_bucket_name,
-                Key=self.get_file_key(anonymous_user_id)
-            )
-        except ClientError as error:
-            if int(error.response["Error"]["Code"]) == HTTPStatus.NOT_FOUND:
-                return False
-            log.error(error)
-            raise error
-        return True
-
-    def get_current_mind_map(self, anonymous_user_id: str) -> dict | None:
+    def get_current_mind_map(self, suffix: str) -> dict | None:
         """
         Return the current mind map content.
 
-        Returns:
-            dict: The mind map content.
-        """
-        if not self.file_exists_in_s3(anonymous_user_id):
-            return None
+        Args:
+            suffix (str): The suffix to use in the key (path).
 
+        Returns:
+            dict: The current mind map content.
+            None: If the file does not exist.
+        """
         s3_client, aws_bucket_name = self.connect_to_s3()
+
         try:
             response = s3_client.get_object(
                 Bucket=aws_bucket_name,
-                Key=self.get_file_key(anonymous_user_id)
+                Key=self.get_file_key(suffix)
             )
             json_data = response["Body"].read().decode("utf-8")
         except ClientError as error:
+            if error.response["Error"]["Code"] == "NoSuchKey":
+                return None
             raise error
         return json.loads(json_data)
 
     @XBlock.json_handler
-    def upload_file(self, data, suffix="") -> None: # pylint: disable=unused-argument
+    def upload_file_student(self, data, _suffix="") -> None:
         """
-        Uploads a mind map file to S3.
+        Uploads a mind map file to S3 as a student.
 
         Args:
             data (dict): The data to upload
-            suffix (str, optional): Defaults to "".
+            _suffix (str, optional): Defaults to "".
         """
         user = self.get_current_user()
         anonymous_user_id = self.anonymous_user_id(user)
@@ -252,11 +284,29 @@ class MindMapXBlock(XBlock):
         )
 
     @XBlock.json_handler
-    def studio_submit(self, data, suffix=""):  # pylint: disable=unused-argument
+    def upload_file_instructor(self, data, _suffix="") -> None:
+        """
+        Uploads a mind map file to S3 as an instructor.
+
+        Args:
+            data (dict): The data to upload
+            _suffix (str, optional): Defaults to "".
+        """
+        s3_client, aws_bucket_name = self.connect_to_s3()
+
+        s3_client.put_object(
+            Bucket=aws_bucket_name,
+            Key=self.get_file_key("instructor"),
+            Body=data.get("mind_map")
+        )
+
+    @XBlock.json_handler
+    def studio_submit(self, data, _suffix=""):
         """
         Called when submitting the form in Studio.
         """
         self.display_name = data.get("display_name")
+        self.is_static = data.get("is_static")
 
     # TO-DO: change this to create the scenarios you'd like to see in the
     # workbench while developing your XBlock.

--- a/mindmap/static/html/mindmap.html
+++ b/mindmap/static/html/mindmap.html
@@ -1,19 +1,24 @@
-{% if show_mindmap %}
+{% if in_student_view or is_static %}
     {% if error_message %}
         <p>The mind map can't be rendered due to the following error: <b>{{error_message}}</b></p>
         <p>Please contact the instructor or an administrator.</p>
     {% else %}
-        <link type="text/css" rel="stylesheet" href="https://unpkg.com/jsmind@latest/style/jsmind.css" />
-        <script type="text/javascript" src="https://unpkg.com/jsmind@latest/es6/jsmind.js"></script>
-        <script type="text/javascript" src="https://unpkg.com/jsmind@latest/es6/jsmind.draggable-node.js"></script>
-
+        <link type="text/css" rel="stylesheet" href="https://unpkg.com/jsmind@latest/style/jsmind.css"/>
         <div>
-            <button class="save-button">Save</button>
+            {% if not in_student_view and is_static %}
+                <button class="save-button-instructor">Save</button>
+            {% endif %}
+            {% if not is_static %}
+                <button class="save-button-student">Save</button>
+            {% endif %}
             <div id="jsmind_container"></div>
         </div>
     {% endif %}
 {% else %}
-<div>
-    <p>The mind map is only visible from the LMS.</p>
-</div>
+    <div>
+        <p>
+            The mind map is only visible from the LMS.
+            If you want to create a static mind map set the "Is Static" field to True.
+        </p>
+    </div>
 {% endif %}

--- a/mindmap/static/html/mindmap.html
+++ b/mindmap/static/html/mindmap.html
@@ -16,9 +16,7 @@
     {% endif %}
 {% else %}
     <div>
-        <p>
-            The mind map is only visible from the LMS.
-            If you want to create a static mind map set the "Is Static" field to True.
-        </p>
+        <p>The mind map is only visible from the LMS.</p>
+        <p>If you want to create a static mind map set the "Is a static mindmap?" field to True.</p>
     </div>
 {% endif %}

--- a/mindmap/static/html/mindmap_edit.html
+++ b/mindmap/static/html/mindmap_edit.html
@@ -9,7 +9,7 @@
     </li>
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
-        <label class="label setting-label" for="mindmap_is_static">Is Static</label>
+        <label class="label setting-label" for="mindmap_is_static">Is a static mindmap?</label>
         <select class="input settings-input" name="mindmap_is_static" id="mindmap_is_static">
           <option value=1 {% if is_static %} selected{% endif %}>True</option>
           <option value=0 {% if not is_static %} selected{% endif %}>False</option>

--- a/mindmap/static/html/mindmap_edit.html
+++ b/mindmap/static/html/mindmap_edit.html
@@ -1,21 +1,32 @@
 <div class="wrapper-comp-settings is-active editor-with-buttons" id="settings-tab">
-    <ul class="list-input settings-list">
-      <li class="field comp-setting-entry is-set">
-        <div class="wrapper-comp-setting">
-          <label class="label setting-label" for="mindmap_display_name">Display name</label>
-          <input class="input setting-input" name="mindmap_display_name" id="mindmap_display_name" value="{{display_name}}" type="text" />
-        </div>
+  <ul class="list-input settings-list">
+    <li class="field comp-setting-entry is-set">
+      <div class="wrapper-comp-setting">
+        <label class="label setting-label" for="mindmap_display_name">Display name</label>
+        <input class="input setting-input" name="mindmap_display_name" id="mindmap_display_name"
+          value="{{display_name}}" type="text" />
+      </div>
+    </li>
+    <li class="field comp-setting-entry is-set">
+      <div class="wrapper-comp-setting">
+        <label class="label setting-label" for="mindmap_is_static">Is Static</label>
+        <select class="input settings-input" name="mindmap_is_static" id="mindmap_is_static">
+          <option value=1 {% if is_static %} selected{% endif %}>True</option>
+          <option value=0 {% if not is_static %} selected{% endif %}>False</option>
+        </select>
+      </div>
+      <span class="tip setting-help">{{ is_static_field.help }}</span>
+    </li>
+  </ul>
+
+  <div class="xblock-actions">
+    <ul>
+      <li class="action-item">
+        <a href="#" class="button action-primary save-button">Save</a>
+      </li>
+      <li class="action-item">
+        <a href="#" class="button cancel-button">Cancel</a>
       </li>
     </ul>
-
-    <div class="xblock-actions">
-      <ul>
-        <li class="action-item">
-          <a href="#" class="button action-primary save-button">Save</a>
-        </li>
-        <li class="action-item">
-          <a href="#" class="button cancel-button">Cancel</a>
-        </li>
-      </ul>
-    </div>
   </div>
+</div>

--- a/mindmap/static/js/src/mindmap.js
+++ b/mindmap/static/js/src/mindmap.js
@@ -20,23 +20,23 @@ function MindMapXBlock(runtime, element, context) {
             theme: "asphalt",
         };
 
-        const jm = new jsMind(options);
-        jm.show(mind);
+        const currentMindMap = new jsMind(options);
+        currentMindMap.show(mind);
 
         $(element).find(".save-button-student").click(function () {
-            saveMindMap(runtime, element, jm, "upload_file_student");
+            saveMindMap(runtime, element, currentMindMap, "student");
         });
 
         $(element).find(".save-button-instructor").click(function () {
-            saveMindMap(runtime, element, jm, "upload_file_instructor");
+            saveMindMap(runtime, element, currentMindMap, "instructor");
         });
     };
 
-    function saveMindMap(runtime, element, mindMap, functionName) {
+    function saveMindMap(runtime, element, mindMap, path_prefix) {
         const mindMapData = mindMap.get_data("node_array");
         const jsonMindMapData = JSON.stringify(mindMapData);
-        const handlerUrl = runtime.handlerUrl(element, functionName);
-        const data = { mind_map: jsonMindMapData };
+        const handlerUrl = runtime.handlerUrl(element, "upload_file");
+        const data = { mind_map: jsonMindMapData, path_prefix: path_prefix };
 
         $.post(handlerUrl, JSON.stringify(data))
             .done(function (response) {

--- a/mindmap/static/js/src/mindmap.js
+++ b/mindmap/static/js/src/mindmap.js
@@ -1,39 +1,90 @@
 // TODO: add notifications
 function MindMapXBlock(runtime, element, context) {
 
-    const baseMind = {
-        "meta": {
-            "name": "Mind Map",
-            "version": "0.1"
-        },
-        "format": "node_array",
-        "data": [
-            { "id": "root", "isroot": true, "topic": "Root" },
-        ]
+    function showMindMap(jsMind, context) {
+        const baseMind = {
+            meta: {
+                name: "Mind Map",
+                version: "0.1",
+            },
+            format: "node_array",
+            data: [{ id: "root", isroot: true, topic: "Root" }],
+        };
+
+        const mind = context.mind_map || baseMind;
+        mind.meta.author = context.author;
+
+        const options = {
+            container: "jsmind_container",
+            editable: context.editable,
+            theme: "asphalt",
+        };
+
+        const jm = new jsMind(options);
+        jm.show(mind);
+
+        $(element).find(".save-button-student").click(function () {
+            saveMindMap(runtime, element, jm, "upload_file_student");
+        });
+
+        $(element).find(".save-button-instructor").click(function () {
+            saveMindMap(runtime, element, jm, "upload_file_instructor");
+        });
     };
 
-    const mind = context.mind_map || baseMind;
-    mind.meta.author = context.author;
-
-    const options = {
-        container: 'jsmind_container',
-        editable: true,
-        theme: 'asphalt',
-    };
-
-    const jm = new jsMind(options);
-    jm.show(mind);
-
-    $(element).find('.save-button').click(function () {
-        const mindMapData = jm.get_data('node_array');
+    function saveMindMap(runtime, element, mindMap, functionName) {
+        const mindMapData = mindMap.get_data("node_array");
         const jsonMindMapData = JSON.stringify(mindMapData);
-        const handlerUrl = runtime.handlerUrl(element, 'upload_file');
+        const handlerUrl = runtime.handlerUrl(element, functionName);
         const data = { mind_map: jsonMindMapData };
 
-        $.post(handlerUrl, JSON.stringify(data)).done(function (response) {
-            window.location.reload(false);
-        }).fail(function () {
-            console.log("Error saving mind map");
+        $.post(handlerUrl, JSON.stringify(data))
+            .done(function (response) {
+                window.location.reload(false);
+            })
+            .fail(function () {
+                console.log("Error saving mind map");
+            });
+    }
+
+    if (typeof require === "function") {
+        require(["jsMind"], function (jsMind) {
+            showMindMap(jsMind, context);
         });
-    });
+    } else {
+        loadJSMind(function () {
+            showMindMap(window.jsMind, context);
+        });
+    }
+}
+
+
+function loadJSMind(callback) {
+    if (window.jsMind) {
+        callback();
+    } else {
+        // Load jsMind dynamically using $.getScript
+        $.getScript("https://unpkg.com/jsmind@latest/es6/jsmind.js")
+            .done(function () {
+                // Assign jsMind to the window object after it's loaded
+                window.jsMind = jsMind;
+
+                // Load jsMind.draggable-node dynamically using $.getScript
+                $.getScript("https://unpkg.com/jsmind@latest/es6/jsmind.draggable-node.js")
+                    .done(function () {
+                        if (window.jsMind) {
+                            // Both jsMind and jsMind.draggable are now loaded and available
+                            callback();
+                        } else {
+                            console.error("Error loading jsMind or jsMind.draggable.");
+                        }
+                    })
+                    .fail(function () {
+                        console.error("Error loading jsMind.draggable-node.");
+                    });
+            })
+            .fail(function () {
+                console.error("Error loading jsMind.");
+            });
+    }
 }

--- a/mindmap/static/js/src/mindmapEdit.js
+++ b/mindmap/static/js/src/mindmapEdit.js
@@ -7,6 +7,7 @@ function MindMapXBlock(runtime, element) {
     const handlerUrl = runtime.handlerUrl(element, 'studio_submit');
     const data = {
       display_name: $(element).find('input[name=mindmap_display_name]').val(),
+      is_static: Number($(element).find('select[name=mindmap_is_static]').val()),
     };
     $.post(handlerUrl, JSON.stringify(data)).done(function (response) {
       window.location.reload(false);

--- a/mindmap/static/js/src/requiredModules.js
+++ b/mindmap/static/js/src/requiredModules.js
@@ -1,0 +1,8 @@
+(function (require) {
+    require.config({
+        paths: {
+            jsMind: "https://unpkg.com/jsmind@latest/es6/jsmind",
+            draggable_plugin: "https://unpkg.com/jsmind@latest/es6/jsmind.draggable-node",
+        },
+    });
+}).call(this, require || RequireJS.require);

--- a/mindmap/static/js/src/requiredModules.js
+++ b/mindmap/static/js/src/requiredModules.js
@@ -1,3 +1,10 @@
+/*
+We're using requirejs library because open edx uses this library to add internal or external modules.
+Check the doc here: https://requirejs.org/
+It's necessary to use this because all modules of this lib won't work as expected. So this is
+adding our modules to the window object that has all modules in the CMS, check this:
+https://github.com/openedx/edx-platform/blob/7e23feeb33861c0de3572364cd103c3929bb0588/common/static/js/RequireJS-namespace.js#L3
+*/
 (function (require) {
     require.config({
         paths: {

--- a/mindmap/tests/test_mindmap.py
+++ b/mindmap/tests/test_mindmap.py
@@ -244,12 +244,12 @@ class TestMindMapUtilities(TestCase):
         Expected result:
             - None is returned.
         """
-        suffix = 'test-anonymous-user-id'
+        path_prefix = 'test-anonymous-user-id'
         s3_client_mock.return_value.get_object.side_effect = ClientError(
             {'Error': {'Code': 'NoSuchKey'}}, 'HeadObject'
         )
 
-        result = self.xblock.get_current_mind_map(suffix)
+        result = self.xblock.get_current_mind_map(path_prefix)
 
         self.assertIsNone(result)
 
@@ -265,8 +265,8 @@ class TestMindMapUtilities(TestCase):
         s3_client_mock.return_value.get_object.return_value = {
             "Body": Mock(read=Mock(return_value=json.dumps(mind_map).encode("utf-8")))
         }
-        suffix = 'test-anonymous-user-id'
+        path_prefix = 'test-anonymous-user-id'
 
-        result = self.xblock.get_current_mind_map(suffix)
+        result = self.xblock.get_current_mind_map(path_prefix)
 
         self.assertEqual(result, mind_map)


### PR DESCRIPTION
### Description
This PR adds functionality for instructors to create static mind maps from Studio, and students can view them in the LMS.

### How To Test
1. Install this branch in your environment.
2. Add a new block from Studio and edit the field `Is Static`, set it to `True`
3. Create a new mind map in the block, and `Save`.
4. In the LMS you should see the mind map created, but you cannot edit it, nor does the `Save` button appear.

### Examples
#### Studio
![image](https://github.com/eduNEXT/xblock-mindmap/assets/64033729/369c167d-5440-46be-867e-ce11087d4ddd)
#### LMS
![image](https://github.com/eduNEXT/xblock-mindmap/assets/64033729/e928da99-dbad-4b9a-b57c-9dd62b0cd5bf)
