### PR TITLE
refactor!: consider not-editable mindmap after submission

### DIFF
--- a/mindmap/mindmap.py
+++ b/mindmap/mindmap.py
@@ -235,6 +235,11 @@ class MindMapXBlock(XBlock):
         """
         user = self.get_current_user()
         context = self.get_context(user)
+        js_context = self.get_js_context(user, context)
+
+        if not context["can_submit_assignment"]:
+            context["editable"] = False
+            js_context["editable"] = False
 
         if self.show_staff_grading_interface():
             context["is_instructor"] = True
@@ -242,7 +247,7 @@ class MindMapXBlock(XBlock):
         frag = self.load_fragment("mindmap", context)
 
         frag.add_javascript(self.resource_string("static/js/src/requiredModules.js"))
-        frag.initialize_js('MindMapXBlock', json_args=self.get_js_context(user, context))
+        frag.initialize_js('MindMapXBlock', json_args=js_context)
 
         return frag
 

--- a/mindmap/tests/test_mindmap.py
+++ b/mindmap/tests/test_mindmap.py
@@ -245,7 +245,7 @@ class TestMindMapXBlock(MindMapXBlockTestMixin):
         expected_context = {
             "display_name": self.xblock.display_name,
             "in_student_view": True,
-            "editable": self.editable_mind_map,
+            "editable": False,
             "xblock_id": block_id,
             "is_static": self.xblock.is_static,
             "is_static_field": self.xblock.fields["is_static"],
@@ -255,7 +255,7 @@ class TestMindMapXBlock(MindMapXBlockTestMixin):
         expected_js_context = {
             "author": self.student.full_name,
             "mind_map": self.mind_map,
-            "editable": self.editable_mind_map,
+            "editable": False,
             "xblock_id": block_id,
         }
 


### PR DESCRIPTION
## Description
This PR considers that a mindmap after submission is not editable in the student view.

## How to test
1. Create a mindmap, add as many nodes as you want
2. Save the mindmap
3. Submit the mindmap
4. Try editing the mindmap