### PR TITLE
refactor: add max score when showing grading to students

### DIFF
--- a/mindmap/mindmap.py
+++ b/mindmap/mindmap.py
@@ -203,6 +203,7 @@ class MindMapXBlock(XBlock):
             "is_static_field": self.fields["is_static"],
             "can_submit_assignment": self.submit_allowed(),
             "score": self.score,
+            "max_score": self.max_score(),
         }
 
     def get_js_context(self, user, context):

--- a/mindmap/tests/test_mindmap.py
+++ b/mindmap/tests/test_mindmap.py
@@ -74,6 +74,7 @@ class TestMindMapXBlock(MindMapXBlockTestMixin):
             "is_static_field": self.xblock.fields["is_static"],
             "can_submit_assignment": True,
             "score": 0,
+            "max_score": self.xblock.max_score(),
         }
         expected_js_context = {
             "author": self.student.full_name,
@@ -112,6 +113,7 @@ class TestMindMapXBlock(MindMapXBlockTestMixin):
             "is_static_field": self.xblock.fields["is_static"],
             "can_submit_assignment": True,
             "score": 0,
+            "max_score": self.xblock.max_score(),
         }
         expected_js_context = {
             "author": self.student.full_name,
@@ -150,6 +152,7 @@ class TestMindMapXBlock(MindMapXBlockTestMixin):
             "is_static_field": self.xblock.fields["is_static"],
             "can_submit_assignment": True,
             "score": 0,
+            "max_score": self.xblock.max_score(),
         }
 
         self.xblock.student_view()
@@ -179,6 +182,7 @@ class TestMindMapXBlock(MindMapXBlockTestMixin):
             "is_static_field": self.xblock.fields["is_static"],
             "can_submit_assignment": True,
             "score": 0,
+            "max_score": self.xblock.max_score(),
             "is_instructor": True,
         }
 
@@ -216,6 +220,7 @@ class TestMindMapXBlock(MindMapXBlockTestMixin):
             "points_field": self.xblock.fields["points"],
             "weight": 1,
             "weight_field": self.xblock.fields["weight"],
+            "max_score": self.xblock.max_score(),
         }
 
         self.xblock.studio_view()
@@ -253,6 +258,7 @@ class TestMindMapXBlock(MindMapXBlockTestMixin):
             "is_static_field": self.xblock.fields["is_static"],
             "can_submit_assignment": False,
             "score": 0,
+            "max_score": self.xblock.max_score(),
         }
         expected_js_context = {
             "author": self.student.full_name,


### PR DESCRIPTION
### Description
This PR adds the max score when showing grading to students.

### Test instructions
First, follow the testing instructions in [this PR](https://github.com/eduNEXT/xblock-mindmap/pull/13) to assign a grade to a student. Then, go to the component as the student, you'll see:
![image](https://github.com/eduNEXT/xblock-mindmap/assets/64440265/90cbcbf8-9259-45d3-87c9-55a97c702b1b)
