### PR TITLE
fix: remove score in student view when the mindmap is static

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,25 @@ Change Log
 Unreleased
 **********
 
+0.8.1 - 2023-09-22
+**********************************************
+
+Changed
+=======
+
+* Remove score in student view when the mindmap is static
+
+
+0.8.0 - 2023-09-22
+**********************************************
+
+Added
+=====
+
+* Add the ability to configure the block as scorable from Studio
+* Show assignment information to students
+
+
 0.7.2 - 2023-09-18
 **********************************************
 

--- a/mindmap/__init__.py
+++ b/mindmap/__init__.py
@@ -4,4 +4,4 @@ Init for the MindMapXBlock package.
 
 from .mindmap import MindMapXBlock
 
-__version__ = '0.7.2'
+__version__ = '0.8.1'

--- a/mindmap/public/html/mindmap.html
+++ b/mindmap/public/html/mindmap.html
@@ -53,9 +53,9 @@
 
 <div id="jsmind_container_{{xblock_id}}" class="jsmind_container"></div>
 
-{% if has_score and not score and in_student_view %}
+{% if not is_static and has_score and not score and in_student_view %}
   <p>(0/{{ max_score }} {% trans "points" %}) {% trans submission_status %}</p>
-{% elif has_score and score and in_student_view %}
+{% elif not is_static and has_score and score and in_student_view %}
   <p>({{ score }}/{{ max_score }} {% trans "points" %}) {% trans submission_status %}</p>
 {% endif %}
 


### PR DESCRIPTION
### Description
This PR removes the score in the student view when the mind map is static.

### How To Test
1. Install this branch in your environment.
2. Add a block in a unit from Studio.
3. Set the **Is a static mindmap?** field in `True`
4. As a student you should not see any scores, only the mind map.

### Screenshots
#### Before
![image](https://github.com/eduNEXT/xblock-mindmap/assets/64033729/d529fc6b-194b-47fb-a8d0-4d6b747dffc6)
#### After
![image](https://github.com/eduNEXT/xblock-mindmap/assets/64033729/67fb119d-d54c-4f77-8b27-c1f672a0fc0e)