### PR TITLE
feat: add author different author view for studio

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Change Log
 Unreleased
 **********
 
+* Add author view to the XBlock to be used in Studio.
+
 0.8.4 - 2023-10-02
 **********************************************
 

--- a/mindmap/mindmap.py
+++ b/mindmap/mindmap.py
@@ -301,10 +301,6 @@ class MindMapXBlock(XBlock, CompletableXBlockMixin):
         context = self.get_context()
         js_context = self.get_js_context(user, context)
 
-        if context["has_score"] and not context["can_submit_assignment"]:
-            context["editable"] = False
-            js_context["editable"] = False
-
         frag = self.load_fragment("mindmap", context)
 
         frag.add_javascript(self.resource_string("public/js/src/requiredModules.js"))
@@ -333,7 +329,9 @@ class MindMapXBlock(XBlock, CompletableXBlockMixin):
             "weight": self.weight,
             "weight_field": self.fields["weight"],
         })
-
+        js_context.update({
+            "editable": True,
+        })
         frag = self.load_fragment("mindmap_edit", context)
 
         frag.initialize_js('MindMapXBlock', json_args=js_context)

--- a/mindmap/mindmap.py
+++ b/mindmap/mindmap.py
@@ -205,7 +205,7 @@ class MindMapXBlock(XBlock, CompletableXBlockMixin):
             template_path, context, i18n_service=self.runtime.service(self, 'i18n')
         )
 
-    def get_context(self):
+    def get_context(self, in_student_view=False):
         """
         Return the context for the student view.
 
@@ -215,11 +215,10 @@ class MindMapXBlock(XBlock, CompletableXBlockMixin):
         Returns:
             dict: The context for the student view
         """
-        in_student_view = self.is_student or self.is_course_team
         if self.is_static:
             editable = False
         else:
-            editable = in_student_view
+            editable = True
 
         context = {
             "display_name": self.display_name,
@@ -271,7 +270,7 @@ class MindMapXBlock(XBlock, CompletableXBlockMixin):
             Fragment: The fragment to render
         """
         user = self.get_current_user()
-        context = self.get_context()
+        context = self.get_context(in_student_view=True)
         js_context = self.get_js_context(user, context)
 
         if context["has_score"] and not context["can_submit_assignment"]:

--- a/mindmap/mindmap.py
+++ b/mindmap/mindmap.py
@@ -301,8 +301,10 @@ class MindMapXBlock(XBlock, CompletableXBlockMixin):
         user = self.get_current_user()
         context = self.get_context()
         js_context = self.get_js_context(user, context)
-        context["editable"] = False
-        js_context["editable"] = False
+
+        if context["has_score"] and not context["can_submit_assignment"]:
+            context["editable"] = False
+            js_context["editable"] = False
 
         frag = self.load_fragment("mindmap", context)
 

--- a/mindmap/mindmap.py
+++ b/mindmap/mindmap.py
@@ -218,7 +218,7 @@ class MindMapXBlock(XBlock, CompletableXBlockMixin):
         if self.is_static:
             editable = False
         else:
-            editable = True
+            editable = in_student_view or self.is_course_team
 
         context = {
             "display_name": self.display_name,

--- a/mindmap/mindmap.py
+++ b/mindmap/mindmap.py
@@ -300,6 +300,8 @@ class MindMapXBlock(XBlock, CompletableXBlockMixin):
         user = self.get_current_user()
         context = self.get_context()
         js_context = self.get_js_context(user, context)
+        context["editable"] = False
+        js_context["editable"] = False
 
         frag = self.load_fragment("mindmap", context)
 

--- a/mindmap/tests/test_mindmap.py
+++ b/mindmap/tests/test_mindmap.py
@@ -251,6 +251,40 @@ class TestMindMapXBlock(MindMapXBlockTestMixin):
             "public/html/mindmap_edit.html", expected_context,
         )
 
+    def test_author_view(self):
+        """
+        Check author view is rendered correctly.
+
+        Expected result:
+            - The studio view is set up for the render.
+        """
+        self.xblock.is_static = False
+        self.xblock.get_current_user.return_value.opt_attrs = {
+            "edx-platform.user_is_staff": True,
+        }
+        self.xblock.is_course_staff = True
+        self.xblock.get_current_mind_map.return_value = self.mind_map
+        expected_context = {
+            "display_name": self.xblock.display_name,
+            "in_student_view": True,
+            "editable": False,
+            "xblock_id": self.xblock.scope_ids.usage_id.block_id,
+            "is_static": self.xblock.is_static,
+            "is_static_field": self.xblock.fields["is_static"],
+            "can_submit_assignment": True,
+            "score": 0,
+            "max_score": self.xblock.max_score(),
+            "has_score": True,
+            "has_score_field": self.xblock.fields["has_score"],
+            "submission_status": self.xblock.submission_status,
+        }
+
+        self.xblock.author_view()
+
+        self.xblock.render_template.assert_called_once_with(
+            "public/html/mindmap.html", expected_context,
+        )
+
     @initialize_js_mock
     def test_student_not_allowed_submission(self, initialize_js_mock: Mock):
         """

--- a/mindmap/tests/test_mindmap.py
+++ b/mindmap/tests/test_mindmap.py
@@ -266,8 +266,8 @@ class TestMindMapXBlock(MindMapXBlockTestMixin):
         self.xblock.get_current_mind_map.return_value = self.mind_map
         expected_context = {
             "display_name": self.xblock.display_name,
-            "in_student_view": True,
-            "editable": False,
+            "in_student_view": False,
+            "editable": True,
             "xblock_id": self.xblock.scope_ids.usage_id.block_id,
             "is_static": self.xblock.is_static,
             "is_static_field": self.xblock.fields["is_static"],

--- a/mindmap/tests/test_mindmap.py
+++ b/mindmap/tests/test_mindmap.py
@@ -267,7 +267,7 @@ class TestMindMapXBlock(MindMapXBlockTestMixin):
         expected_context = {
             "display_name": self.xblock.display_name,
             "in_student_view": False,
-            "editable": True,
+            "editable": False,
             "xblock_id": self.xblock.scope_ids.usage_id.block_id,
             "is_static": self.xblock.is_static,
             "is_static_field": self.xblock.fields["is_static"],


### PR DESCRIPTION
### Description
This PR adds an author view that differs from the student view so we better manage what to show Studio authors. Before these changes, what was shown was manage by the same student view which shows the grading interface unless these conditions meet:

```
def show_staff_grading_interface(self) -> bool:
        """
        Return if current user is staff and not in studio.

        Returns:
            bool: True if current user is instructor and not in studio.
        """
        in_studio_preview = self.scope_ids.user_id is None
        return not in_studio_preview and self.is_course_team
```
In_studio_preview returns the user ID when we're in the studio preview, so the check returned True when it wasn't supposed to since `self.scope_ids.user_id` is different than None in Studio preview using edx-platforms' master branch (although it's supposed to return None according to [these](https://github.com/openedx/edx-ora2/blob/9f105e54cd62d537bb27f14a13cc7c5835072ae2/openassessment/xblock/openassessmentblock.py#L712-L714) docs, I'm not sure what's wrong). It was probably working because the user wasn't course staff but an instructor, so the overall check returned false before the changes [in this PR](https://github.com/eduNEXT/xblock-mindmap/pull/27). 

Also, `in_student_view` which allows loading the scripts for mindmaps, should indicate whether we're in the student view not if the user has a role like it was before.

### How to test
Install the Xblock as usual, then go to the components' Studio preview. It should show the default mindmap. Also, when using a static mindmap it should show the default static mindmap. The Studio edit should work as well.
